### PR TITLE
Add an attribute with always numeric version number

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,15 @@ Branch names in DistGit:
 Only version numbers:
 
 ```python
->>> [x.version for x in aliases["fedora-stable"]]
-['38', '39']
+>>> [x.version for x in aliases["fedora-all"]]
+['38', '39', 'rawhide']
+```
+
+If you need a numeric version even for rawhide:
+
+```python
+>>> [x.version_number for x in aliases["fedora-all"]]
+['38', '39', '40']
 ```
 
 

--- a/fedora_distro_aliases/__init__.py
+++ b/fedora_distro_aliases/__init__.py
@@ -33,7 +33,7 @@ def get_distro_aliases():
     epel = []
 
     distros = [Distro.from_bodhi_release(x) for x in releases if x.name != "ELN"]
-    distros.sort(key=lambda x: int(x.version))
+    distros.sort(key=lambda x: int(x.version_number))
 
     epel = [x for x in distros if x.product == "epel"]
     fedora = [x for x in distros if x.product == "fedora"]
@@ -79,7 +79,9 @@ class Distro(Munch):
         Create a `Distro` object from Bodhi `release`
         """
         keys = ["name", "long_name", "version", "state", "branch", "id_prefix"]
-        return cls({k: getattr(release, k) for k in keys})
+        distro = cls({k: getattr(release, k) for k in keys})
+        distro.version_number = release.version
+        return distro
 
     @property
     def product(self):

--- a/tests/test_fedora_distro_aliases.py
+++ b/tests/test_fedora_distro_aliases.py
@@ -40,6 +40,7 @@ def test_distro():
     assert distro.namever == "foo-123"
     assert distro.product == "fedora"
     assert distro.product == "fedora"
+    assert distro.version_number == "123"
     assert "nonsense" not in distro
     assert "additional" not in distro
 
@@ -62,3 +63,9 @@ def test_f40_branch_to_final_release_window(requests_get):
     namevers = [x.namever for x in aliases["fedora-all"]]
     expected = ["fedora-38", "fedora-39", "fedora-40", "fedora-rawhide"]
     assert namevers == expected
+
+    versions = [x.version for x in aliases["fedora-all"]]
+    assert versions == ["38", "39", "40", "rawhide"]
+
+    version_numbers = [x.version_number for x in aliases["fedora-all"]]
+    assert version_numbers == ["38", "39", "40", "41"]


### PR DESCRIPTION
Fix #9

For example for Fedora Rawhide that would mean that `distro.version` will be `"rawhide"` and `distro.version_number` will be e.g. `"41"`.