### PR TITLE
releases can have Y part (dot in the release)

### DIFF
--- a/fedora_distro_aliases/__init__.py
+++ b/fedora_distro_aliases/__init__.py
@@ -33,7 +33,7 @@ def get_distro_aliases():
     epel = []
 
     distros = [Distro.from_bodhi_release(x) for x in releases if x.name != "ELN"]
-    distros.sort(key=lambda x: int(x.version_number))
+    distros.sort(key=lambda x: float(x.version_number))
 
     epel = [x for x in distros if x.product == "epel"]
     fedora = [x for x in distros if x.product == "fedora"]


### PR DESCRIPTION
Addressing:
Traceback (most recent call last):
  File "/usr/bin/tito", line 33, in <module>
    sys.exit(load_entry_point('tito==0.6.26', 'console_scripts', 'tito')())
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/tito/cli.py", line 944, in main
    CLI().main(sys.argv[1:])
  File "/usr/lib/python3.12/site-packages/tito/cli.py", line 210, in main
    return module.main(argv)
           ^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/tito/cli.py", line 635, in main
    releaser = releaser_class(
               ^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/tito/release/distgit.py", line 66, in __init__
    self.git_branches = self._branches()
                        ^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/tito/release/distgit.py", line 111, in _branches
    aliases = get_distro_aliases()
              ^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/fedora_distro_aliases/__init__.py", line 36, in get_distro_aliases
    distros.sort(key=lambda x: int(x.version_number))
  File "/usr/lib/python3.12/site-packages/fedora_distro_aliases/__init__.py", line 36, in <lambda>
    distros.sort(key=lambda x: int(x.version_number))
                               ^^^^^^^^^^^^^^^^^^^^^
ValueError: invalid literal for int() with base 10: '10.0'

Fixes: #17